### PR TITLE
Fix #28 query required createcomputer

### DIFF
--- a/templates/domain_join.erb
+++ b/templates/domain_join.erb
@@ -146,7 +146,7 @@ function query {
   is_joined_to_domain
   _is_joined_to_domain=$?
   if [ $_is_joined_to_domain = 0 ]; then
-    echo "${upper_host} is joined to the domain"
+    echo "<%= @hostname %> is joined to the domain"
     #TODO only force if a shell flag is given?
     #force_add_if_sssd_service_broken
     exit 0

--- a/templates/domain_join.erb
+++ b/templates/domain_join.erb
@@ -48,11 +48,6 @@ register_account='<%= @register_account %>'
 register_password='<%= @register_password %>'
 <%- if @createcomputer then -%>container_ou='<%= @createcomputer %>'<%- end -%>
 
-if [[ -z "${container_ou// }" ]] ; then
-  echo "Unable to query without setting an OU. Puppet class variable 'createcomputer' was undef." 1>&2
-  exit 1
-fi
-
 function restart_sshd {
   <%- case @operatingsystemmajrelease
   when "6" -%>
@@ -116,8 +111,8 @@ function is_service_running {
 
 
 function is_joined_to_domain {
-  upper_host=<%= @hostname.upcase %>
-  net ads dn "CN=${upper_host},OU=${container_ou},<%= 'DC=' + @domain_fqdn.split('.').join(',DC=') %>" -U ${register_account}%${register_password}
+  # Use Computer Account (-P) to query domain
+  net ads dn "<%= 'DC=' + @domain_fqdn.split('.').join(',DC=') %>" distinguishedName -P -l
   EXIT_CODE=$?
   [ "$EXIT_CODE" == '0' ] && return 0 || return 1
 }
@@ -156,7 +151,7 @@ function query {
     #force_add_if_sssd_service_broken
     exit 0
   else
-    echo "${upper_host} is not joined to the domain, or service account has lost access"
+    echo "<%= @hostname %> is not joined to the domain, or computer account has lost access"
     exit 1
   fi
 }


### PR DESCRIPTION
Issues that led to this change...

* createcomputer was *not* optional, even though the init.pp said it was, so our domain_join script was exit 1'ing before it ever joined, so we added `domain_join::createcomputers: Computers` to hieradata, which worked around that... but

* The domain_join script was hanging on subsequent puppet runs because it was trying to join again, because the "query" was failing (no such object)... because it is "CN=Computers,(domain)" not "OU=Computers,(domain)" ...

So I re-wrote the query to just query the "(domain)" but using the "-P" (computer account) which will only work if the computer is joined to the domain, seems better all around, tested and works for us.

~tommy