### PR TITLE
Feature/rhel6-rhel7 compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,15 +16,29 @@ class domain_join (
   $interface = 'eno16780032',         # The interface associated with the DNS entry. Default for EL7 VMs.
   $join_domain = true,                # set to false to just run configuration and not join the domain.
 ) {
-  $service_packages = [
+
+  $service_packages_tmp = [
     'oddjob-mkhomedir',
     'krb5-workstation',
     'krb5-libs',
     'sssd-common',
     'sssd-ad',
+    'sssd-tools',
+    'ldb-tools',
     'samba-common',
-    'samba-common-tools',
   ]
+
+
+  ## Since this is a RHEL-based module, we need to distinguish between RHEL 6 and 7
+  ##   and then add 'samba-common-tools' package to the package list for RHEL 7 only
+  if downcase( $facts['os']['family'] ) == 'redhat' {
+    if $facts['os']['release']['major'] == '6' {
+      $service_packages = $service_packages_tmp
+    }
+    if $facts['os']['release']['major'] == '7' {
+      $service_packages = concat($service_packages_tmp, ['samba-common-tools'])
+    }
+  }
 
   if $manage_services {
     ensure_packages($service_packages, {'ensure' => 'present'})

--- a/spec/classes/domain_join_spec.rb
+++ b/spec/classes/domain_join_spec.rb
@@ -7,14 +7,20 @@ describe 'domain_join', :type => :class do
         facts
       end
       context 'with defaults for all parameters' do
-        it { is_expected.to create_class('domain_join') }
+        if facts[:operatingsystemmajrelease] == '7'
+            it { is_expected.to contain_package('samba-common-tools') }
+        elsif facts[:operatingsystemmajrelease] == '6'
+            it { is_expected.not_to contain_package('samba-common-tools') }
+        end
         it { is_expected.to contain_package('oddjob-mkhomedir') }
         it { is_expected.to contain_package('krb5-workstation') }
         it { is_expected.to contain_package('krb5-libs') }
         it { is_expected.to contain_package('samba-common') }
-    it { is_expected.to contain_package('samba-common-tools') }
         it { is_expected.to contain_package('sssd-ad') }
         it { is_expected.to contain_package('sssd-common') }
+        it { is_expected.to contain_package('sssd-tools') }
+        it { is_expected.to contain_package('ldb-tools') }
+        it { is_expected.to create_class('domain_join') }
         it { is_expected.to contain_file('/etc/resolv.conf') }
         it { is_expected.to contain_file('/etc/krb5.conf') }
         it { is_expected.to contain_file('/etc/samba/smb.conf') }


### PR DESCRIPTION
Hello Rob,

     I'm working with `brettswift` who is another collaborator on this module.

     I found an issue when it comes to what packages need to be installed when the target system is RHEL6 or RHEL7. RHEL7 requires 'samba-common-tools' package but the same isn't available for RHEL6. Moreover, the content of 'samba-common-tools' is included in other RHEL6's packages. I solved it by adding a couple of 'if' statements.

    There're multiple ways to program it but I followed this: keep a list of the common packages and add 'samba-common-tools' when the target server is RHEL7.

    Second change is add two more packages regardless RHEL version for troubleshooting and to get extra utilities:

   -- sssd-tools: to get tools such as 'sssctl' which allows to get the active domain controller name, get AD controllers latest status, cached users/groups and their expiration dates, etc etc. Another interested tool in this package is 'sss-seed' that lets you create users in sssd cache in the event a server gets offlline meaning these cached users can still log in though the server has no connection to AD (i.e. due to AD outage)

-- ldb-tools: it manipulates LDB files such as sssd cache file. You can query sssd cache for advanced user and group data retrieval.

   These two packages are more for troubleshooting purposes and are widely available in RHEL6/RHEL7 repositories.

   Thanks and happy to contribute!
     